### PR TITLE
Add coverage. Fix duplicate ConversionExtensionTests method name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,7 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Test reports and coverage
+tests/coverage/
+tests/reports/

--- a/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
+++ b/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
@@ -4,16 +4,29 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- Add for coverage -->
+  <PropertyGroup>
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutput>../tests/reports/$(MSBuildProjectName)/</CoverletOutput>
+    <CoverletOutputFormat>opencover</CoverletOutputFormat>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Ainsworth.Extensions.Tests/ConversionExtensionsTests.cs
+++ b/Ainsworth.Extensions.Tests/ConversionExtensionsTests.cs
@@ -58,7 +58,7 @@ public class ConversionExtensionsTests
 
     [DataTestMethod]
     [DynamicData(nameof(LongStrings), DynamicDataSourceType.Property)]
-    public void ParseLong_string__returns_same_value_as_Int64Parse(object obj) {
+    public void ParseLong_object__returns_same_value_as_Int64Parse(object obj) {
         var actual = obj.ParseLong();
         var expected = Int64.Parse((string)obj);
         Assert.AreEqual(expected, actual);

--- a/util/generate-coverage.sh
+++ b/util/generate-coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+##
+# Generate test coverage report
+##
+# re: https://medium.com/@nocgod/how-to-setup-your-dotnet-project-with-a-test-coverage-reporting-6ff1903f7240
+# dotnet add package coverlet.collector
+# dotnet add package coverlet.msbuild
+
+# Preparation
+
+# dotnet tool install -g dotnet-coverage
+# dotnet tool install -g dotnet-reportgenerator-globaltool
+
+set -o errexit
+set -o nounset
+
+# Cleanup and Rebuild
+
+dotnet clean
+dotnet build
+
+# Execution
+
+TEST_DIR="tests"
+TEST_REPORTS_DIR="$TEST_DIR/reports"
+COVERAGE_DIR="$TEST_DIR/coverage"
+COVERAGE_REPORT_DIR="$COVERAGE_DIR/report"
+COVERAGE_HISTORY_DIR="$COVERAGE_DIR/history"
+
+mkdir -p $TEST_DIR $TEST_REPORTS_DIR
+mkdir -p $COVERAGE_DIR $COVERAGE_REPORT_DIR $COVERAGE_HISTORY_DIR
+
+dotnet test --collect:"XPlat Code Coverage" \
+ 	--logger "html;logfilename=test-report.html;verbosity=detailed"
+
+# https://reportgenerator.io/usage
+reportgenerator \
+	-reports:"$TEST_REPORTS_DIR/*/*.xml" \
+ 	-targetdir:"$COVERAGE_REPORT_DIR" \
+ 	-reporttypes:"Html" \
+ 	-historydir:"$COVERAGE_HISTORY_DIR" \
+ 	-assemblyfilters:"-*.Tests.dll" \
+ 	-verbosity:"Warning" \
+ 	-title:"${PWD##*/}"
+	#-sourcedirs:"src" \
+
+# open tests/coverage/report/index.html
+
+# end


### PR DESCRIPTION
Add coverage computation and report.
Fix duplicate test method name in `ConversionExtensionsTests`.
Upgrade NuGet test packages.

Close #6 