### PR TITLE
build: Configure GitVersion

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "6.0.2",
+      "commands": [
+        "dotnet-gitversion"
+      ]
+    }
+  }
+}

--- a/Ainsworth.Extensions/Ainsworth.Extensions.csproj
+++ b/Ainsworth.Extensions/Ainsworth.Extensions.csproj
@@ -22,4 +22,12 @@
     <None Include="../LICENSE" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <Target Name="GitVersion-update" BeforeTargets="PrebuildEvent">
+    <Exec Command="$(SolutionDir)/util/gitversion.sh update $(TargetFramework) $(Configuration)" />
+  </Target>
+
+  <Target Name="GitVersion-clean" AfterTargets="Clean">
+    <Exec Command="$(SolutionDir)/util/gitversion.sh clean $(TargetFramework) $(Configuration)" />
+  </Target>
+
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,12 @@
-mode: ContinuousDelivery
+workflow: GitFlow/v1
+assembly-versioning-scheme: MajorMinorPatchTag
+assembly-file-versioning-scheme: MajorMinorPatchTag
+#assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{PreReleaseNumber}'
+#assembly-versioning-format: '{Major}.{Minor}.{Patch}.{PreReleaseNumber}'
+assembly-informational-format: '{Major}.{Minor}.{Patch}{PreReleaseTagWithDash}+{Sha}'
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-,/\\\\]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING[ -]CHANGE:\\s.+)|\\+semver:\\s?(breaking|major)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-,/\\\\]*\\))?:|\\+semver:\\s?(feature|minor)"
+patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-,/\\\\]*\\))?:|\\+semver:\\s?(fix|patch)"
 branches: {}
 ignore:
   sha: []

--- a/util/gitversion.sh
+++ b/util/gitversion.sh
@@ -1,13 +1,60 @@
 #!/usr/bin/env bash
 ##
-# Run gitversion on packable projects only (ignore test projects)
+# Run gitversion to set version numbers.
+#
+# NOTE: While GitVersion has an MSBuild Task (https://gitversion.net/docs/usage/msbuild),
+# is does not work with .NET Standard projects. So, this scripting hack takes its place.
+#
+# WARNING: this code may be fragile under parallel builds, which is the default for
+# the `dotnet` command. So far though, it works--at least on macOS 🤞. (This is not my
+# favorite strategy.)
 ##
 
-find * -type f -name '*.csproj' ! -name '*.Tests.csproj' \
-| while read f; do
-    cd "$(dirname "$f")"
-    dotnet-gitversion /updateprojectfiles \
-    | sed '/InformationalVersion/!d; s/^ *"//; s/"//g; s/,$//'
-done
+set -o nounset
+set -o errexit
+
+VERSION_FILE='AssemblyVersionInfo.cs'
+SCRIPT="$(basename "$0")"
+
+echo "$SCRIPT $*"
+
+#set | sed "s/^/$SCRIPT: /"
+
+if [[ "$1" == "update" ]]; then
+
+    dotnet tool restore
+    echo "InformationalVersion -> $(dotnet tool run dotnet-gitversion /showvariable InformationalVersion /updateprojectfiles)"
+
+elif [[ "$1" == "clean" ]]; then
+
+    for csproj in *.csproj; do
+        echo "$SCRIPT: clean $csproj"
+        gawk '
+            # Skip version lines
+            /^\s*<AssemblyVersion>.*<\/AssemblyVersion>\s*$/ { next }
+            /^\s*<FileVersion>.*<\/FileVersion>\s*$/ { next }
+            /^\s*<InformationalVersion>.*<\/InformationalVersion>\s*$/ { next }
+            /^\s*<Version>.*<\/Version>\s*$/ { next }
+
+            # Put back blank lines removed by dotnet-gitversion
+            /^\s*<PropertyGroup>\s*$/ { print "" }
+            /^\s*<ItemGroup>\s*$/ { print "" }
+            /^\s*<Target .*>\s*$/ { print "" }
+            /^\s*<\/Project>\s*$/ { print "" }
+
+            # copy all lines not a version
+            { print }
+        ' "$csproj" | uniq >"$csproj.$$"
+        if cmp -s "$csproj" "$csproj.$$"; then
+            rm "$csproj.$$"
+        else
+            mv "$csproj.$$" "$csproj"
+        fi
+    done
+
+else
+    echo "unknown subcommand: $1"
+    exit 1
+fi
 
 # end


### PR DESCRIPTION
Configure GitVersion to automatically update the version number, and to remove the version numbers from the csproj file on clean.

- Configure GitVersion in `.config/dotnet-tools.json`. Use the current version (currently 6.0.2),
- Configure `GitVersion.yml`,
- Add build targets to add and remove version number from project files, and
- Add a script to support the build targets.

closes #24 