### PR TITLE
Switch to central build properties and package management

### DIFF
--- a/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
+++ b/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
+++ b/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
@@ -14,14 +14,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Ainsworth.Extensions/Ainsworth.Extensions.csproj
+++ b/Ainsworth.Extensions/Ainsworth.Extensions.csproj
@@ -4,14 +4,12 @@
     <Product>Ainsworth.System.Chaining</Product>
     <AssemblyTitle>Ainsworth.System.Chaining</AssemblyTitle>
     <Description>Extension methods to make built-in static methods appear available as instance methods. For example, Char.IsLetter(c) can be written c.IsLetter(). This package adds no new functionality. It just enables method chaining and makes interfaces to some System classes a bit more fluent.</Description>
-    <Copyright>©️2023 Scott G. Ainsworth</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <!-- <TargetFrameworks>net8.0;netstandard2.0;netstandard2.1</TargetFrameworks> -->
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackRelease>true</PackRelease>
     <AnalysisMode>All</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Directory.Package.props documentation:
+  https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management
+ -->
+
+<Project>
+
+  <!-- Properties common to all projects in this solution -->
+  <PropertyGroup>
+    <LangVersion>12.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Authors>Scott G. Ainsworth</Authors>
+    <Copyright>©️2023 Scott G. Ainsworth</Copyright>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Directory.Package.props documentation:
+  https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management
+ -->
+<Project>
+  <!-- Properties common to all projects in this solution -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+    <PackageVersion Include="GitVersion.MSBuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Move common build properties to `Directory.Build.props` and
- Move package version properties to `Directory.Packages.props`.

Closes #26 
