### PR TITLE
chore: Stabilize GitVersion operations

### DIFF
--- a/Ainsworth.Extensions/Ainsworth.Extensions.csproj
+++ b/Ainsworth.Extensions/Ainsworth.Extensions.csproj
@@ -21,12 +21,14 @@
     <None Include="../LICENSE" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="GitVersion-update" BeforeTargets="PrebuildEvent">
-    <Exec Command="$(SolutionDir)/util/gitversion.sh update $(TargetFramework) $(Configuration)" />
+  <Target Name="GitVersionUpdate" BeforeTargets="DispatchToInnerBuilds">
+    <Exec Command="echo IsCrossTargetingBuild = '$(IsCrossTargetingBuild)'" EchoOff="true" />
+    <Exec Command="../util/gitversion.sh update $(TargetFramework) $(Configuration)" />
   </Target>
 
-  <Target Name="GitVersion-clean" AfterTargets="Clean">
-    <Exec Command="$(SolutionDir)/util/gitversion.sh clean $(TargetFramework) $(Configuration)" />
+  <Target Name="GitVersionClean" AfterTargets="Clean" Condition="'$(IsCrossTargetingBuild)' == 'true'">
+    <Exec Command="echo IsCrossTargetingBuild = '$(IsCrossTargetingBuild)'" EchoOff="true" />
+    <Exec Command="../util/gitversion.sh clean" />
   </Target>
 
 </Project>

--- a/util/environment-dump-command.xml
+++ b/util/environment-dump-command.xml
@@ -1,0 +1,55 @@
+﻿  <Target Name="GitVersion-update" BeforeTargets="PrebuildEvent">
+    <Exec Command="set" />
+    <Exec Command="
+        echo &quot;ApplicationIcon              = '$(ApplicationIcon)'&quot;
+        echo &quot;AssemblyName                 = '$(AssemblyName)'&quot;
+        echo &quot;BuildInParallel              = $(BuildInParallel)&quot;
+        echo &quot;Configuration                = '$(Configuration)'&quot;
+        echo &quot;DebugType                    = '$(DebugType)'&quot;
+        echo &quot;Deterministic                = $(Deterministic)&quot;
+        echo &quot;DevEnvDir                    = '$(DevEnvDir)'&quot;
+        echo &quot;DirectoryBuildPropsPath      = '$(DirectoryBuildPropsPath)'&quot;
+        echo &quot;DirectoryBuildTargetsPath    = '$(DirectoryBuildTargetsPath)'&quot;
+        echo &quot;DocumentationFile            = '$(DocumentationFile)'&quot;
+        echo &quot;ImportDirectoryBuildProps    = $(ImportDirectoryBuildProps)&quot;
+        echo &quot;ImportDirectoryBuildTargets  = $(ImportDirectoryBuildTargets)&quot;
+        echo &quot;MSBuildTreatWarningsAsErrors = '$(MSBuildTreatWarningsAsErrors)'&quot;
+        echo &quot;MSBuildWarningsAsErrors      = '$(MSBuildWarningsAsErrors)'&quot;
+        echo &quot;MSBuildWarningsAsMessages    = '$(MSBuildWarningsAsMessages)'&quot;
+        echo &quot;NoLogo                       = $(NoLogo)&quot;
+        echo &quot;NoStdLib                     = $(NoStdLib)&quot;
+        echo &quot;NoWarn                       = '$(NoWarn)'&quot;
+        echo &quot;Optimize                     = $(Optimize)&quot;
+        echo &quot;OptionExplicit               = $(OptionExplicit)&quot;
+        echo &quot;OptionInfer                  = $(OptionInfer)&quot;
+        echo &quot;OptionStrict                 = $(OptionStrict)&quot;
+        echo &quot;OutDir                       = '$(OutDir)'&quot;
+        echo &quot;OutputPath                   = '$(OutputPath)'&quot;
+        echo &quot;OutputType                   = '$(OutputType)'&quot;
+        echo &quot;Platform                     = '$(Platform)'&quot;
+        echo &quot;ProcessorArchitecture        = '$(ProcessorArchitecture)'&quot;
+        echo &quot;ProduceReferenceOnlyAssembly = $(ProduceReferenceOnlyAssembly)&quot;
+        echo &quot;ProductReferenceAssembly     = $(ProductReferenceAssembly)&quot;
+        echo &quot;ProjectDir                   = '$(ProjectDir)'&quot;
+        echo &quot;ProjectPath                  = '$(ProjectPath)'&quot;
+        echo &quot;ProjectName                  = '$(ProjectName)'&quot;
+        echo &quot;ProjectFileName              = '$(ProjectFileName)'&quot;
+        echo &quot;ProjectExt                   = '$(ProjectExt)'&quot;
+        echo &quot;RootNameSpace                = '$(RootNameSpace)'&quot;
+        echo &quot;SolutionDir                  = '$(SolutionDir)'&quot;
+        echo &quot;SolutionPath                 = '$(SolutionPath)'&quot;
+        echo &quot;SolutionName                 = '$(SolutionName)'&quot;
+        echo &quot;SolutionFileName             = '$(SolutionFileName)'&quot;
+        echo &quot;SolutionExt                  = '$(SolutionExt)'&quot;
+        echo &quot;TargetFramework              = '$(TargetFramework)'&quot;
+        echo &quot;TargetFrameworkVersion       = '$(TargetFrameworkVersion)'&quot;
+        echo &quot;TreatWarningsAsErrors        = $(TreatWarningsAsErrors)&quot;
+        echo &quot;Utf8Output                   = $(Utf8Output)&quot;
+        echo &quot;WarningsAsErrors             = '$(WarningsAsErrors)'&quot;
+        echo &quot;WarningLevel                 = '$(WarningLevel)'&quot;
+        echo &quot;WarningsNotAsErrors          = '$(WarningsNotAsErrors)'&quot;
+        echo &quot;pwd                          = '$$(pwd)'&quot;
+      " />
+  </Target>
+
+</Project>

--- a/util/gitversion.sh
+++ b/util/gitversion.sh
@@ -13,43 +13,60 @@
 set -o nounset
 set -o errexit
 
+##
+# fix csproj spacing that dotnet-gitversion messes up (stdin -> stdout)
+function fixup_csproj_spacing() {
+    gawk '
+        # Put back blank lines removed by dotnet-gitversion
+        /^\s*<PropertyGroup>\s*$/ { print "" }
+        /^\s*<ItemGroup>\s*$/ { print "" }
+        /^\s*<Target .*>\s*$/ { print "" }
+        /^\s*<\/Project>\s*$/ { print "" }
+
+        # copy all lines not a version
+        { print }
+    ' | uniq
+}
+
+##
+# Rename if csproj changed
+# $1 = original csproj file
+# $2 = re-spaced csproj file
+function roll_csproj() {
+    cmp -s "$1" "$2" && rm "$2" || mv "$2" "$1"
+}
+
 VERSION_FILE='AssemblyVersionInfo.cs'
 SCRIPT="$(basename "$0")"
 
-echo "$SCRIPT $*"
-
-#set | sed "s/^/$SCRIPT: /"
-
 if [[ "$1" == "update" ]]; then
 
+    # restore dotnet-gitversion tool
     dotnet tool restore
+
+    # update the project files and show the version
     echo "InformationalVersion -> $(dotnet tool run dotnet-gitversion /showvariable InformationalVersion /updateprojectfiles)"
+    for csproj in *.csproj; do
+        cat "$csproj" | fixup_csproj_spacing >"$csproj.$$"
+        roll_csproj "$csproj" "$csproj.$$"
+    done
 
 elif [[ "$1" == "clean" ]]; then
 
+    # clean all projects (usually just one)
     for csproj in *.csproj; do
-        echo "$SCRIPT: clean $csproj"
         gawk '
-            # Skip version lines
-            /^\s*<AssemblyVersion>.*<\/AssemblyVersion>\s*$/ { next }
-            /^\s*<FileVersion>.*<\/FileVersion>\s*$/ { next }
-            /^\s*<InformationalVersion>.*<\/InformationalVersion>\s*$/ { next }
-            /^\s*<Version>.*<\/Version>\s*$/ { next }
-
-            # Put back blank lines removed by dotnet-gitversion
-            /^\s*<PropertyGroup>\s*$/ { print "" }
-            /^\s*<ItemGroup>\s*$/ { print "" }
-            /^\s*<Target .*>\s*$/ { print "" }
-            /^\s*<\/Project>\s*$/ { print "" }
-
-            # copy all lines not a version
+          # Skip version lines
+            /^\s*<AssemblyVersion>.*<\/AssemblyVersion>\s*$/ ||
+            /^\s*<FileVersion>.*<\/FileVersion>\s*$/ ||
+            /^\s*<InformationalVersion>.*<\/InformationalVersion>\s*$/ ||
+            /^\s*<Version>.*<\/Version>\s*$/ {
+              next
+            }
+          # Copy everything else
             { print }
-        ' "$csproj" | uniq >"$csproj.$$"
-        if cmp -s "$csproj" "$csproj.$$"; then
-            rm "$csproj.$$"
-        else
-            mv "$csproj.$$" "$csproj"
-        fi
+        ' "$csproj" | fixup_csproj_spacing > "$csproj.$$"
+        roll_csproj "$csproj" "$csproj.$$"
     done
 
 else


### PR DESCRIPTION
- Modify `gitversion.sh` to fix line spacing on 'update' as it already does on 'clean'.
- Update project targets so that `gitversion.sh` is run once per dotnet command.
- Make GitVersion operations work properly when run from VSCode.

Resolves #31 