### PR TITLE
fix: Remove duplicate commit hash from Informational Version

### DIFF
--- a/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
+++ b/Ainsworth.Extensions.Tests/Ainsworth.Extensions.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Prevent .NET 8+ SDK from adding commit SHA to Informational version -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <!-- Add for coverage -->

--- a/Ainsworth.Extensions/Ainsworth.Extensions.csproj
+++ b/Ainsworth.Extensions/Ainsworth.Extensions.csproj
@@ -6,11 +6,10 @@
     <AssemblyTitle>Ainsworth.Extensions</AssemblyTitle>
     <Description>Extension methods to make built-in static methods appear available as instance methods. For example, Char.IsLetter(c) can be written c.IsLetter(). This package adds no new functionality. It just enables method chaining and makes interfaces to some System classes a bit more fluent.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <PackRelease>true</PackRelease>
+    <!-- Prevent .NET 8+ SDK from adding commit SHA to Informational version -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix: Remove duplicate commit hash from Informational Version